### PR TITLE
feat: Add README.md and basic commercial website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
+# Configurable JSON Viewer
 
+## Introduction
+
+This application is a configurable JSON viewer. It allows users to load, navigate, and interact with JSON data in a user-friendly interface.
+
+The current focus of this viewer is to serve as a browser for the **iNNitiatives Process Guide**, a framework for innovation management.
+
+## For Users
+
+### Loading Data
+
+There are several ways to load JSON data into the viewer:
+
+*   **Drag & Drop**: Drag a JSON file from your computer and drop it onto the application window.
+*   **File Selection**: Click on the designated "Load File" button (if available) to open a file dialog and select a JSON file.
+*   **Default File (URL Parameter)**: The application can be configured to load a default JSON file automatically. This is specified using the `defaultFile` URL parameter (e.g., `index.html?defaultFile=path/to/your/data.json`).
+
+### Navigating Data
+
+The application provides two main ways to navigate the loaded JSON data:
+
+*   **Tree Sidebar**: A hierarchical tree structure is displayed in the sidebar, representing the nested nature of the JSON data. Click on nodes in the tree to view their content.
+*   **Content Display Area**: The main area of the application displays the content of the selected JSON node.
+    *   **Special Fields**: Certain field names (e.g., `title`, `content`) may be rendered in specific ways for better readability.
+    *   **Markdown**: Content within fields designated for rich text (typically a "content" field) will be rendered as Markdown, allowing for formatted text, lists, links, etc.
+    *   **Tags**: Items can have associated tags, which are displayed and can be used for filtering or highlighting (future potential).
+
+### Interacting with Content
+
+*   **Relation Tags**: The application supports special "relation tags" that can link different parts of the JSON data. Clicking on these tags might navigate to the related item (this functionality may be further developed).
+
+### Exporting Data
+
+Users can export the currently viewed content in the following formats:
+
+*   **Markdown**: Exports the content as a Markdown file.
+*   **HTML**: Exports the content as an HTML file.
+
+## For Technical Users/Developers
+
+### Application Stack
+
+The application is built using the following technologies:
+
+*   **Vue.js**: A progressive JavaScript framework for building user interfaces.
+*   **Tailwind CSS**: A utility-first CSS framework for rapid UI development.
+*   **Lucide Icons**: A clean and consistent icon set.
+
+### Configuration
+
+The application can be configured through the `APP_CONFIG` JavaScript object within the `index.html` file. URL parameters can override these settings.
+
+*   **`APP_CONFIG` in `index.html`**:
+    *   `appName` (String): The name of the application, displayed in the header.
+    *   `version` (String): The application version, displayed in the footer.
+    *   `showHeader` (Boolean): Toggles the visibility of the header.
+    *   `showFooter` (Boolean): Toggles the visibility of the footer.
+    *   `showSidebar` (Boolean): Toggles the visibility of the sidebar.
+    *   `defaultFile` (String): URL or path to a JSON file to load by default.
+    *   `logoUrl` (String): URL or path to an image file to be used as the logo in the header.
+
+*   **URL Parameters for Override**:
+    *   Example: `index.html?appName=MyCustomViewer&defaultFile=data/my_data.json`
+
+### Data Format (referencing `sample.json`)
+
+The viewer expects JSON data in a specific, though flexible, hierarchical structure. Refer to the `sample.json` file for a concrete example.
+
+*   **Expected JSON Structure**: Typically an array of objects, where each object can have child objects (often in a `children` array), forming a tree.
+*   **Special Field Rendering**:
+    *   `id`: A unique identifier for an item. Used for linking and navigation.
+    *   `title`: The primary display name for an item, often shown in the tree and as a heading in the content view.
+    *   `content`: A field containing the main information, typically rendered as Markdown.
+    *   `tags`: An array of strings representing tags associated with the item.
+*   **Tag Format**:
+    *   Simple tags: `key::value` (e.g., `status::active`)
+    *   Relation tags: `relationKey>>targetId` (e.g., `relatedProcess>>PROC-001`). These tags can be used to create navigable links between different items in the JSON data.
+*   **Markdown in Content Fields**: Fields named `content` (or configured alternative) are parsed as Markdown, allowing for rich text formatting.
+
+### How to Run
+
+1.  Ensure you have a modern web browser.
+2.  Clone or download the application files.
+3.  Open the `index.html` file directly in your web browser.
+
+### Customization
+
+The application is designed to be customizable:
+
+*   **Vue Components**: Key components like `TreeNode.js` (for rendering individual nodes in the tree) and `ContentViewer.js` (for displaying the content of a selected node) can be modified to change their appearance or behavior.
+*   **Styling**: Tailwind CSS classes can be adjusted in the HTML templates of the Vue components or in `index.html`.
+
+## Project Purpose (iNNitiatives context from `sample.json`)
+
+*   **Viewer's Initial Use-Case**: This JSON viewer was initially developed to navigate and understand the **"iNNitiatives Process Guide"**.
+*   **Brief on iNNitiatives Process Guide**: The iNNitiatives Process Guide is a comprehensive framework for managing innovation within an organization. It details:
+    *   **Program Structure**: The overall organization of innovation efforts.
+    *   **Roles**: Responsibilities and expectations for individuals involved in the innovation process.
+    *   **Opportunities**: Identifying and evaluating potential areas for innovation.
+    *   **Initiatives**: The lifecycle and management of specific innovation projects.
+
+The `sample.json` file provides an example of how this guide is structured and represented in JSON format for use with this viewer.

--- a/commercial.html
+++ b/commercial.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Insight Navigator - JSON Data Viewer & Innovation Guide Tool</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; color: #333; }
+        nav { background-color: #f4f4f4; padding: 1rem; text-align: center; display: flex; align-items: center; justify-content: space-around; }
+        nav img { height: 40px; margin-right: 1rem; }
+        nav .app-name { font-size: 1.5rem; font-weight: bold; }
+        nav a { text-decoration: none; color: #333; margin: 0 1rem; }
+        .hero { background-color: #e9e9e9; padding: 2rem; text-align: center; }
+        .hero h1 { font-size: 2.5rem; margin-bottom: 1rem; }
+        .hero p { font-size: 1.2rem; margin-bottom: 1.5rem; }
+        .cta-button { background-color: #333; color: white; padding: 0.8rem 1.5rem; text-decoration: none; border-radius: 5px; margin: 0.5rem; display: inline-block; }
+        .cta-button:hover { background-color: #555; }
+        .features { padding: 2rem; text-align: center; }
+        .features h2 { font-size: 2rem; margin-bottom: 1.5rem; }
+        .features ul { list-style: none; padding: 0; display: flex; justify-content: center; gap: 2rem; }
+        .features li { margin-bottom: 1rem; font-size: 1.1rem; background-color: #f9f9f9; padding: 1rem; border-radius: 5px; width: 200px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        footer { background-color: #333; color: white; text-align: center; padding: 1rem; margin-top: 2rem; }
+        footer a { color: white; text-decoration: none; margin: 0 0.5rem; }
+    </style>
+</head>
+<body>
+    <nav>
+        <div>
+            <img src="https://innv0.com/assets/innv0_logo.svg" alt="Insight Navigator Logo">
+            <span class="app-name">Insight Navigator</span>
+        </div>
+        <div>
+            <a href="index.html">Viewer</a>
+            <a href="README.md">Documentation</a>
+        </div>
+    </nav>
+
+    <section class="hero">
+        <h1>Unlock Insights from Your Innovation Processes</h1>
+        <p>Visually navigate complex structured data like the iNNitiatives Process Guide with our intuitive JSON Viewer. Gain clarity and make informed decisions.</p>
+        <a href="index.html" class="cta-button">Launch Viewer</a>
+        <a href="README.md" class="cta-button">Learn More</a>
+    </section>
+
+    <section class="features">
+        <h2>Key Features</h2>
+        <ul>
+            <li>Interactive Tree Navigation</li>
+            <li>Markdown & Tag Support</li>
+            <li>Data Export (Markdown/HTML)</li>
+        </ul>
+    </section>
+
+    <footer>
+        <p>© 2024 Insight Navigator</p>
+        <p>
+            <a href="index.html">Viewer</a> |
+            <a href="README.md">Documentation</a> |
+            <a href="#">Back to Top</a>
+        </p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Generates a comprehensive README.md with instructions for you and technical users, detailing the application's purpose, usage, configuration, and data format.

Also adds a new `commercial.html` page to serve as a basic landing page for the application, providing a brief overview and links to the viewer and documentation.